### PR TITLE
added visibility hidden when alpha is 0

### DIFF
--- a/opacity.js
+++ b/opacity.js
@@ -3,5 +3,15 @@ module.exports = function( item, data ) {
   if( data.alpha !== undefined ) {
 
     item.style.opacity = data.alpha;
+
+    if( data.alpha === 0 && item.style.visibility !== "hidden"){
+
+      item.style.visibility = "hidden";
+
+    } else if(item.style.visibility === "hidden"){
+
+      item.style.visibility = "visible";
+
+    }
   }
 };

--- a/opacity.js
+++ b/opacity.js
@@ -8,7 +8,7 @@ module.exports = function( item, data ) {
 
       item.style.visibility = "hidden";
 
-    } else if(item.style.visibility === "hidden"){
+    } else if(item.style.visibility === "hidden" && data.alpha !== 0){
 
       item.style.visibility = "visible";
 

--- a/transform.js
+++ b/transform.js
@@ -39,9 +39,10 @@ module.exports = function( item, data ) {
 
     cssValue = 'perspective( ' + perspective + 'px ) matrix3d(' + Array.prototype.join.call( transform, ',' ) + ')';
 
-    item.style[ 'transform' ] = cssValue;
-    item.style[ '-webkit-transform' ] = cssValue;
-    item.style[ '-ms-transform' ] = cssValue;
-    item.style[ '-moz-transform' ] = cssValue;
+    item.style.transform = cssValue;
+    item.style.webkitTransform = cssValue;
+    item.style.msTransform = cssValue;
+    item.style.MozTransform = cssValue;
+    item.style.OTransform = cssValue;
   }
 };

--- a/transform.js
+++ b/transform.js
@@ -40,8 +40,8 @@ module.exports = function( item, data ) {
     cssValue = 'perspective( ' + perspective + 'px ) matrix3d(' + Array.prototype.join.call( transform, ',' ) + ')';
 
     item.style[ 'transform' ] = cssValue;
-    item.style[ '--webkit-transform' ] = cssValue;
-    item.style[ '--ms-transform' ] = cssValue;
-    item.style[ '--moz-transform' ] = cssValue;
+    item.style[ '-webkit-transform' ] = cssValue;
+    item.style[ '-ms-transform' ] = cssValue;
+    item.style[ '-moz-transform' ] = cssValue;
   }
 };

--- a/transformOrigin.js
+++ b/transformOrigin.js
@@ -5,9 +5,10 @@ module.exports = function( item, data ) {
     var anchor = data.anchor || [ 0.5, 0.5 ],
         cssValue = Math.round( anchor[ 0 ] * 100 ) + '% ' + Math.round( anchor[ 1 ] * 100 ) + '%';
 
-    item.style[ 'transform-origin' ] = cssValue;
-    item.style[ '--webkit-transform-origin' ] = cssValue;
-    item.style[ '--ms-transform-origin' ] = cssValue;
-    item.style[ '--moz-transform-origin' ] = cssValue;
+    item.style.transform = cssValue;
+    item.style.webkitTransform = cssValue;
+    item.style.msTransform = cssValue;
+    item.style.MozTransform = cssValue;
+    item.style.OTransform = cssValue;
   }
 };


### PR DESCRIPTION
Prevents elements with 0 opacity from triggering click events. Should improve browser rendering performance.
