### PR TITLE
Add the parent element to the list of potential targets

### DIFF
--- a/lib/getTargetsFromStates.js
+++ b/lib/getTargetsFromStates.js
@@ -26,4 +26,7 @@ module.exports = function(el, targets, states) {
       targets[ elTargetName ] = nodes[ i ];
     }
   }
+
+  // Add the container to potential target list as well
+  if (elTargetName = el.getAttribute('data-f1')) targets[ elTargetName ] = el;
 };


### PR DESCRIPTION
This is especially useful for react-f1. It enables you to target the react-f1 container div.

```
<ReactF1 
go={this.state.state}
onComplete={this.state.onComplete}
states={states(this.props)}
transitions={transitions(this.props)}
data-f1="container"
>
</ReactF1>
```
