### PR TITLE
CSS Filters Support

### DIFF
--- a/lib/applyFilter.js
+++ b/lib/applyFilter.js
@@ -56,7 +56,7 @@ function generateShadow(dropShadow){
   } 
 
   return style;
-}
+};
 
 function generateRgb(colour){
 
@@ -67,11 +67,11 @@ function generateRgb(colour){
     style = 'rgb(' + rounded.join(',') + ')';
   } 
   else if(colour.length == 4) {
-    // we want alpha to be not rounded
-    rounded[ 3 ] = state.style[ propertyStyle ][ 3 ];
+
+    rounded[3] = state.style[propertyStyle][3];
 
     style = 'rgba(' + rounded.join(',') + ')';
   }
 
   return style;
-}
+};

--- a/lib/applyFilter.js
+++ b/lib/applyFilter.js
@@ -1,39 +1,39 @@
 module.exports = function applyFilter(data) {
   
-    if(data.style && (data.style.blur || data.style.brightness || data.style.contrast || data.style.dropShadow || data.style.grayscale || data.style.hueRotate || data.style.invert || data.style.saturate || data.style.sepia)) {
-      
-      var blur = data.style.blur || 0;
-      var brightness = data.style.brightness || 1
-      var contrast = data.style.contrast || 1;
-      var dropShadow = data.style.dropShadow || [0,0,0];
-      var grayscale = data.style.grayscale || 0;
-      var hueRotate = data.style.hueRotate || 0;
-      var invert = data.style.invert || 0;
-      var saturate = data.style.saturate || 1;
-      var sepia = data.style.sepia || 0;
+  if(data.style && (data.style.blur || data.style.brightness || data.style.contrast || data.style.dropShadow || data.style.grayscale || data.style.hueRotate || data.style.invert || data.style.saturate || data.style.sepia)) {
+    
+    var blur = data.style.blur || 0;
+    var brightness = data.style.brightness || 1
+    var contrast = data.style.contrast || 1;
+    var dropShadow = data.style.dropShadow || [0,0,0];
+    var grayscale = data.style.grayscale || 0;
+    var hueRotate = data.style.hueRotate || 0;
+    var invert = data.style.invert || 0;
+    var saturate = data.style.saturate || 1;
+    var sepia = data.style.sepia || 0;
 
-      var filter = '';
+    var filter = '';
 
-      while( dropShadow.length < 3 ) {
+    while( dropShadow.length < 3 ) {
 
-        dropShadow.push( 0 );
-      }
-
-      filter += 'blur(' + blur + 'px) ';
-      filter += 'brightness(' + brightness*100 + '%) ';
-      filter += 'contrast(' + contrast*100 + '%) ';
-      filter += 'grayscale(' + grayscale*100 + '%) ';
-      filter += 'hue-rotate(' + hueRotate + 'deg) ';
-      filter += 'saturate(' + saturate + ') ';
-      filter += 'sepia(' + sepia*100 + '%) ';
-      filter += 'drop-shadow(' + generateShadow(dropShadow) + ') ';
-
-      return filter;
-    } 
-
-    else {
-      return null;
+      dropShadow.push( 0 );
     }
+
+    filter += 'blur(' + blur + 'px) ';
+    filter += 'brightness(' + brightness*100 + '%) ';
+    filter += 'contrast(' + contrast*100 + '%) ';
+    filter += 'grayscale(' + grayscale*100 + '%) ';
+    filter += 'hue-rotate(' + hueRotate + 'deg) ';
+    filter += 'saturate(' + saturate + ') ';
+    filter += 'sepia(' + sepia*100 + '%) ';
+    filter += 'drop-shadow(' + generateShadow(dropShadow) + ') ';
+
+    return filter;
+  } 
+
+  else {
+    return null;
+  }
  
 };
 

--- a/lib/applyFilter.js
+++ b/lib/applyFilter.js
@@ -1,5 +1,3 @@
-var scientificToDecimal = require('scientific-to-decimal');
-
 module.exports = function applyFilter(data) {
   
     if(data.style && (data.style.blur || data.style.brightness || data.style.contrast || data.style.dropShadow || data.style.grayscale || data.style.hueRotate || data.style.invert || data.style.saturate || data.style.sepia)) {
@@ -47,11 +45,11 @@ function generateShadow(dropShadow){
       style = style.concat(generateRgb(dropShadow[i]));
     }
     else if(i < dropShadow.length-1){
-      style = style.concat(scientificToDecimal(dropShadow[i]) + 'px ');
+      style = style.concat(dropShadow[i] + 'px ');
      }
   
     else{
-      style = style.concat(scientificToDecimal(dropShadow[i]) + 'px rgb(0,0,0)');
+      style = style.concat(dropShadow[i] + 'px rgb(0,0,0)');
     }
   } 
 

--- a/lib/applyFilter.js
+++ b/lib/applyFilter.js
@@ -1,0 +1,77 @@
+var scientificToDecimal = require('scientific-to-decimal');
+
+module.exports = function applyFilter(data) {
+  
+    if(data.style && (data.style.blur || data.style.brightness || data.style.contrast || data.style.dropShadow || data.style.grayscale || data.style.hueRotate || data.style.invert || data.style.saturate || data.style.sepia)) {
+      
+      var blur = data.style.blur || 0;
+      var brightness = data.style.brightness || 1
+      var contrast = data.style.contrast || 1;
+      var dropShadow = data.style.dropShadow || [0,0,0];
+      var grayscale = data.style.grayscale || 0;
+      var hueRotate = data.style.hueRotate || 0;
+      var invert = data.style.invert || 0;
+      var saturate = data.style.saturate || 1;
+      var sepia = data.style.sepia || 0;
+
+      var filter = '';
+
+      while( dropShadow.length < 3 ) {
+
+        dropShadow.push( 0 );
+      }
+
+      filter += 'blur(' + blur + 'px) ';
+      filter += 'brightness(' + brightness*100 + '%) ';
+      filter += 'contrast(' + contrast*100 + '%) ';
+      filter += 'grayscale(' + grayscale*100 + '%) ';
+      filter += 'hue-rotate(' + hueRotate + 'deg) ';
+      filter += 'saturate(' + saturate + ') ';
+      filter += 'sepia(' + sepia*100 + '%) ';
+      filter += 'drop-shadow(' + generateShadow(dropShadow) + ') ';
+
+      return filter;
+    } 
+
+    else {
+      return null;
+    }
+ 
+};
+
+function generateShadow(dropShadow){
+  var style = '';
+
+  for(var i in dropShadow){
+    if(Array.isArray(dropShadow[i])){
+      style = style.concat(generateRgb(dropShadow[i]));
+    }
+    else if(i < dropShadow.length-1){
+      style = style.concat(scientificToDecimal(dropShadow[i]) + 'px ');
+     }
+  
+    else{
+      style = style.concat(scientificToDecimal(dropShadow[i]) + 'px rgb(0,0,0)');
+    }
+  } 
+
+  return style;
+}
+
+function generateRgb(colour){
+
+  var rounded = colour.map(Math.round);
+  var style;
+
+  if(colour.length == 3) {
+    style = 'rgb(' + rounded.join(',') + ')';
+  } 
+  else if(colour.length == 4) {
+    // we want alpha to be not rounded
+    rounded[ 3 ] = state.style[ propertyStyle ][ 3 ];
+
+    style = 'rgba(' + rounded.join(',') + ')';
+  }
+
+  return style;
+}

--- a/parsers/filter.js
+++ b/parsers/filter.js
@@ -1,0 +1,44 @@
+var applyFilter = require('../lib/applyFilter');
+
+module.exports = function(target, state) {
+
+  var targetName = target.getAttribute('data-f1');
+
+  if(state.style.blur){
+    state.style.blur, "blur", targetName;
+  }
+
+  if(state.style.brightness){
+    state.style.brightness, "brightness", targetName;
+  }
+
+  if(state.style.contrast){
+    state.style.contrast, "contrast", targetName;
+  }
+
+  if(state.style.dropShadow){
+    state.style.dropShadow, "dropShadow", targetName;
+  }
+
+  if(state.style.grayscale){
+    state.style.grayscale, "grayscale", targetName;
+  }
+
+  if(state.style.hueRotate){
+    state.style.hueRotate, "hueRotate", targetName;
+  }
+
+  if(state.style.saturate){
+    state.style.saturate, "saturate", targetName;
+  }
+
+  if(state.style.sepia){
+    state.style.sepia, "sepia", targetName;
+  }
+  var cssValue = applyFilter(state);
+
+  if(cssValue) {
+    target.style.filter = cssValue;
+    target.style.webkitFilter = cssValue;
+  }
+};

--- a/parsers/index.js
+++ b/parsers/index.js
@@ -9,6 +9,7 @@ module.exports = {
     require('./fill'),
     require('./stroke'),
     require('./transform'),
-    require('./transformOrigin')
+    require('./transformOrigin'),
+    require('./filter')
   ]
 };


### PR DESCRIPTION
Adds in support for:
- blur
- brightness
- contrast
- drop-shadow
- grayscale
- hue-rotate
- invert
- saturate
- sepia

These are applied to `f1` elements just as all `f1` styles. The exception to this is `drop-shadow` which needs to do something a little different to allow support for different shadow colours. It accepts something like `[20,10,5,[255,255,255]]`, with the second array being the shadow's RGB value. This is of course optional, and simply putting in `[20,10,5]` will produce a black shadow.
